### PR TITLE
Changed lang mentions to Livvi Karelian

### DIFF
--- a/.gut/delta.toml
+++ b/.gut/delta.toml
@@ -5,5 +5,5 @@ template_sha = "4712e7cbb43166fccf1100b5e6791c0f3de2f261"
 [replacements]
 __REPO__ = "lang-olo"
 __UND2C__ = "olo"
-__UNDEFINED__ = "Livvi"
+__UNDEFINED__ = "Livvi Karelian"
 __UND__ = "olo"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Olonets Karelian morphology and tools
+The Livvi Karelian morphology and tools
 ==========================================
 
 [![Maturity](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-olo%2Fgh-pages%2Fmaturity.json)](https://giellalt.github.io/MaturityClassification.html)
@@ -16,7 +16,7 @@ Download nightly / CI/CD installation packages for testing (contains the core zh
 
 __NB!!__ Note that the nightly / CI/CD installation packages are not tested for language quality, and might contain regressions and errors.
 
-This repository contains finite state source files for the Olonets Karelian language,
+This repository contains finite state source files for the Livvi Karelian language,
 for building morphological analysers, proofing tools
 and dictionaries. The data and implementation are licenced under GNU GPL
 licence, also detailed in the
@@ -25,7 +25,7 @@ authors named in the AUTHORS file are available to grant other licencing
 choices.
 
 Install proofing tools and [keyboards](https://github.com/giellalt/keyboard-olo)
-for the Olonets Karelian language by using the [Divvun Installer](http://divvun.no)
+for the Livvi Karelian language by using the [Divvun Installer](http://divvun.no)
 (some languages are only available via the nightly channel).
 
 Download and test speller files
@@ -48,7 +48,7 @@ Documentation can be found at:
 Core dependencies
 -----------------
 
-In order to compile and use Olonets Karelian language morphology and
+In order to compile and use Livvi Karelian language morphology and
 dictionaries, you need:
 
 - an FST compiler: [HFST](https://github.com/hfst/hfst), [Foma](https://github.com/mhulden/foma) or [Xerox Xfst](https://web.stanford.edu/~laurik/fsmbook/home.html)

--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_SUBST([GLANG2], [olo])
 AC_SUBST([GTLANG2], $GLANG2)
 # GLANGUAGE is the full language name as given by the ISO 639-3 file.
 # GTLANGUAGE is deprecated, defined for backwards compatibility.
-AC_SUBST([GLANGUAGE], ["Livvi"])
+AC_SUBST([GLANGUAGE], ["Livvi Karelian"])
 AC_SUBST([GTLANGUAGE], $GLANGUAGE)
 
 ### Speller release version (usually different from the package version,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
-title: Livvi NLP Grammar
+title: Livvi Karelian NLP Grammar
 description: Finite state and Constraint Grammar based analysers, proofing tools and other resources
 plugins:
   - jemoji

--- a/docs/index-header.md
+++ b/docs/index-header.md
@@ -1,4 +1,4 @@
-# Livvi documentation
+# Livvi Karelian documentation
 
 [![Maturity](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-olo%2Fgh-pages%2Fmaturity.json)](https://giellalt.github.io/MaturityClassification.html)
 ![Lemma count](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgiellalt%2Flang-olo%2Fgh-pages%2Flemmacount.json)
@@ -6,7 +6,7 @@
 [![Issues](https://img.shields.io/github/issues/giellalt/lang-olo)](https://github.com/giellalt/lang-olo/issues)
 [![Build Status](https://divvun-tc.giellalt.org/api/github/v1/repository/giellalt/lang-olo/main/badge.svg)](https://github.com/giellalt/lang-olo/actions)
 
-This page documents the work on the [Livvi, or Olonets, language model](http://github.com/giellalt/lang-olo). 
+This page documents the work on the [Livvi Karelian language model](http://github.com/giellalt/lang-olo). 
 It contains some 56000 stems and the core morphology, and is in use in a morphological dictionary.
 
 
@@ -14,7 +14,7 @@ It contains some 56000 stems and the core morphology, and is in use in a morphol
 
 ## Resources
 
-* [Language technology tools for Livvi based on the present language model](https://giellatekno.uit.no/cgi/index.olo.eng.html)
+* [Language technology tools for Livvi Karelian based on the present language model](https://giellatekno.uit.no/cgi/index.olo.eng.html)
 
 # In-source documentation
 

--- a/giella-olo.pc.in
+++ b/giella-olo.pc.in
@@ -6,6 +6,6 @@ dir=${datadir}/giella/${gtlang}
 srcdir=${datadir}/giella/${gtlang}
 
 Name: giella-olo
-Description: Finite-state language processing tools for Livvi
+Description: Finite-state language processing tools for Livvi Karelian
 URL: https://giellalt.uit.no/index.html
 Version: @VERSION@

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,17 +1,17 @@
-spellername = "Livvi"
+spellername = "Livvi Karelian"
 spellerversion = "0.1.1"
 
 # Name of the speller package in various languages.
 # The default is English + autonym:
 [speller.name]
-en = "Livvi spellchecker"
+en = "Livvi Karelian spellchecker"
 olo = "Autonym spellchecker"
 
 # Description of the speller package in various languages.
 # The default is English + autonym:
 [speller.description]
-en = "A spellchecker for Livvi, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
-olo = "TRANSLATE: A spellchecker for Livvi, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
+en = "A spellchecker for Livvi Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
+olo = "TRANSLATE: A spellchecker for Livvi Karelian, made by members of the language community, and by the Divvun and Giellatekno groups at UiT The Arctic University of Norway"
 
 [macos]
 system_pkg_id = "no.divvun.MacDivvun.olo"

--- a/src/cg3/disambiguator.cg3
+++ b/src/cg3/disambiguator.cg3
@@ -3,7 +3,7 @@
 
 
 #   ================================= #
-#!! Disambiguator for Olonets
+#!! Disambiguator for Livvi Karelian
 #   ================================= #
 
 # Copied from fit 22.3.21.

--- a/src/fst/morphology/affixes/adjectives.lexc
+++ b/src/fst/morphology/affixes/adjectives.lexc
@@ -1,4 +1,4 @@
-!! # Livvi adjective inflection
+!! # Livvi Karelian adjective inflection
 ! --------------------
 
 

--- a/src/fst/morphology/affixes/adverbs.lexc
+++ b/src/fst/morphology/affixes/adverbs.lexc
@@ -1,6 +1,6 @@
 !! Adverbs 
 !  --------------------
-!! Olonets-Karelian adverbs compare.
+!! Livvi Karelian adverbs compare.
 
 LEXICON ADA_
 +AdA: # ;

--- a/src/fst/morphology/affixes/clitics.lexc
+++ b/src/fst/morphology/affixes/clitics.lexc
@@ -1,6 +1,6 @@
 !! Clitics
 !  --------------------
-!! Livvi clitics
+!! Livvi Karelian clitics
 
 LEXICON K
 +Clt/gi:%>gi WORD-END "also / -kin" ;

--- a/src/fst/morphology/affixes/nouns.lexc
+++ b/src/fst/morphology/affixes/nouns.lexc
@@ -1,6 +1,6 @@
 !! # Noun inflection
 ! ---------------
-!! Livvi nouns inflect in cases.
+!! Livvi Karelian nouns inflect in cases.
 !! Vowel harmony involves front and back
 !! Gradation does not affect all consonants, therefore
 !! there are three values: Yes, No and NA (not applicable)

--- a/src/fst/morphology/affixes/numerals.lexc
+++ b/src/fst/morphology/affixes/numerals.lexc
@@ -13,7 +13,7 @@
 ! giellatekno@uit.no or feedback@divvun.no
 
 ! ############################## !
-!! # Olonets numerals 
+!! # Livvi Karelian numerals 
 ! ############################## !
 
 !! # Numeral inflection

--- a/src/fst/morphology/affixes/prefixes.lexc
+++ b/src/fst/morphology/affixes/prefixes.lexc
@@ -1,6 +1,6 @@
 !! Prefixes
 !  --------
-!! Prefixes in the Livvi language are bound to beginning of other words.
+!! Prefixes in the Livvi Karelian language are bound to beginning of other words.
 
 LEXICON Prefixes
 nounprefix-     Nouns   ;

--- a/src/fst/morphology/affixes/pronouns.lexc
+++ b/src/fst/morphology/affixes/pronouns.lexc
@@ -1,6 +1,6 @@
 !! Pronoun inflection
 !  ---------------
-!! Livvi pronouns inflect for case.
+!! Livvi Karelian pronouns inflect for case.
 
 
 !  By default all pronouns get all number/case

--- a/src/fst/morphology/affixes/propernouns.lexc
+++ b/src/fst/morphology/affixes/propernouns.lexc
@@ -1,6 +1,6 @@
 !! Proper noun inflection
 !  ----------------------
-!! The LIVVI-KARELIAN language proper nouns inflect in the same cases as regular
+!! The LIVVI KARELIAN language proper nouns inflect in the same cases as regular
 !! nouns, but sometimes with a colon (':') as separator.
 
 LEXICON PROP_ !!≈ @CODE@ 

--- a/src/fst/morphology/affixes/quantifiers.lexc
+++ b/src/fst/morphology/affixes/quantifiers.lexc
@@ -1,6 +1,6 @@
 !! Quantifier inflection
 !  ---------------
-!! Livvi quantifiers inflect for case.
+!! Livvi Karelian quantifiers inflect for case.
 
 !LEXICON NUM_
 !+TYÄ: # ;

--- a/src/fst/morphology/phonology.twolc
+++ b/src/fst/morphology/phonology.twolc
@@ -1,4 +1,4 @@
-!! # The Livvi (Olonets) Karelian morphophonological/twolc rules file 
+!! # The Livvi Karelian morphophonological/twolc rules file 
 
 !! This file documents the [phonology.twolc file](http://github.com/giellalt/lang-olo/blob/main/src/fst/phonology.twolc) 
 
@@ -93,11 +93,11 @@ V3:0  !!≈ **@CODE@**
 
 !! no change
 !! The example here is for something that should not be done
-!! We have two infinite sets, Olonets-Karelian and incoming loanwords.
+!! We have two infinite sets, Livvi Karelian and incoming loanwords.
 !! The original idea was to make a rule changing all instances of 
 !! adjacent double aa to ua. For this reason a special trigger was
 !! to be inserted into the lexc stem of a word to prevent such a rule
-!! from occurring. Since the infinite Olonets-Karelian set is more predictable
+!! from occurring. Since the infinite Livvi Karelian set is more predictable
 !! and perhaps smaller than the incoming loanword set, it is better
 !! to literally spell out adjacent vowels that are constant. 2019-09-02 JMR
 %^NONE:0 !!≈ @CODE@ This will break vowel change, e.g. sa%^NONEamelaine

--- a/src/fst/morphology/root.lexc
+++ b/src/fst/morphology/root.lexc
@@ -1,4 +1,4 @@
-! Divvun & Giellatekno - open source grammars for Livvi language
+! Divvun & Giellatekno - open source grammars for Livvi Karelian language
 ! Copyright © 2015 The University of Tromsø & the Norwegian Sámi Parliament
 ! http://giellatekno.uit.no & http://divvun.no
 !
@@ -12,7 +12,7 @@
 ! Other licensing options are available upon request, please contact
 ! giellatekno@uit.no or feedback@divvun.no
 
-!! # The tags and root lexica of the morphological fst of Livvi
+!! # The tags and root lexica of the morphological fst of Livvi Karelian
 
 !! ## Multichar symbols
 
@@ -24,7 +24,7 @@ Multichar_Symbols
 +Ex/V	!!≈ * **@CODE@** - This tag is not added in lexc. The POS tag before derivation is converted into this tag when compiling FST for disambiguation.
 
 
-!! The morphological analyses of wordforms of Livvi are presented
+!! The morphological analyses of wordforms of Livvi Karelian are presented
 !! in this system in terms of following symbols.
 !! (It is highly suggested to follow existing standards when adding new tags).
 

--- a/src/fst/morphology/stems/exceptions.lexc
+++ b/src/fst/morphology/stems/exceptions.lexc
@@ -212,7 +212,7 @@ vazitakseh+V:vazita VR_  "olla varovainen, varoa, karttaa" ;
 žiiloittua+V:žiiloitta V_KANDUA  "(yougi:) polttaa nokkosella; (yougi:) piestä nokkosella" ;
 žualuijakseh+V:žualui VR_SUVAIJA  "valittaa jllek" ;
 
-!! PROPER NOUNS FROM OLONETS
+!! PROPER NOUNS FROM LIVVI KARELIAN
 Iisussu+N:Iisussa PROP_AKKU "" ;
 Iivan+N:Iivan PROP_KARJAL "" ;
 Puavil+N:Puavil PROP_KARJAL "" ;

--- a/src/fst/morphology/stems/numerals.lexc
+++ b/src/fst/morphology/stems/numerals.lexc
@@ -1,6 +1,6 @@
 !! Numerals
 !  --------
-!! Numerals in the Livvi language are numbers.
+!! Numerals in the Livvi Karelian language are numbers.
 
 
 LEXICON Numerals 

--- a/src/fst/morphology/stems/rus-Cyrl-2-Lat-propernouns.lexc
+++ b/src/fst/morphology/stems/rus-Cyrl-2-Lat-propernouns.lexc
@@ -20,7 +20,7 @@
 
 ! The source of this is the URJ-Cyrl (common Uralic Cyrillic) 
 ! proper noun lexicon 100% equivalent to Russian
-! These have been converted according to Olonets transcription
+! These have been converted according to Livvi Karelian transcription
 ! =========================================
 
 LEXICON rus-Cyrl-2-Lat-ProperNouns

--- a/src/fst/orthography/spellrelax.regex
+++ b/src/fst/orthography/spellrelax.regex
@@ -1,4 +1,4 @@
-# Spellrelax for Olonets
+# Spellrelax for Livvi Karelian
 
 c ʼ (->) c %’, #Modifier Letter Apostrophe 02BC written 
 C ʼ (->) C %’, #Right single quotation mark 2019

--- a/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
+++ b/src/fst/transcriptions/transcriptor-abbrevs2text.lexc
@@ -1,4 +1,4 @@
-! Divvun & Giellatekno - open source grammars for Livvi language
+! Divvun & Giellatekno - open source grammars for Livvi Karelian language
 ! Copyright © 2021 The University of Tromsø & the Norwegian Sámi Parliament
 ! http://giellatekno.uit.no & http://divvun.no
 !
@@ -18,10 +18,10 @@
 ! to work.
 
 ! ========================================================================== !
-! !!            !!!Livvi abbreviations                               !
+! !!            !!!Livvi Karelian abbreviations                              !
 ! ========================================================================== !
 
-!! We describe here how abbreviations are in Livvi are read out, e.g.
+!! We describe here how abbreviations are in Livvi Karelian are read out, e.g.
 !! for text-to-speech systems.
 
 LEXICON Root

--- a/src/fst/transcriptions/transcriptor-clock-digit2text.lexc
+++ b/src/fst/transcriptions/transcriptor-clock-digit2text.lexc
@@ -13,7 +13,7 @@
 ! giellatekno@uit.no or feedback@divvun.no
 
 ! ========================== !
-! The Olonets-Karelian clock !
+!  The Livvi Karelian clock  !
 ! ========================== !
 
 ! textbook source: Gilojeva, N. & Rudakova, S. 2009. Karjalan kielen livvin murdehen algukursu. Petroskoi (75–77)

--- a/src/fst/transcriptions/transcriptor-date-digit2text.lexc
+++ b/src/fst/transcriptions/transcriptor-date-digit2text.lexc
@@ -13,7 +13,7 @@
 ! giellatekno@uit.no or feedback@divvun.no
 
 ! ================================== !
-! The Livvi Karelian (Olonets) dates !
+!      The Livvi Karelian dates      !
 ! ================================== !
 
 ! pakkaskuu 1

--- a/tools/grammarcheckers/index.xml
+++ b/tools/grammarcheckers/index.xml
@@ -2,7 +2,7 @@
 <hfstspeller dtdversion="1.0" hfstversion="3">
   <info>
     <locale>olo</locale>
-    <title>Livvi Speller</title>
+    <title>Livvi Karelian Speller</title>
     <description>This speller is used in conjunction with the grammar checker,
     and is only used as part of the development cycle. The main feature is that
     the acceptor is a full analyser, to feed into the CG stream.</description>
@@ -12,7 +12,7 @@
     <contact email="feedback@divvun.no" website="http://divvun.no"/>
   </info>
   <acceptor type="general" id="acceptor.default.hfst">
-    <title>Livvi analysing speller</title>
+    <title>Livvi Karelian analysing speller</title>
     <description>Speller lexicon with analysis output.</description>
   </acceptor>
   <errmodel id="errmodel.default.hfst">

--- a/tools/mt/apertium/tagsets/README.txt
+++ b/tools/mt/apertium/tagsets/README.txt
@@ -15,7 +15,7 @@ modify-rags.TARGETLANG.regex - pair-specific changes using regex, manually m.
 apertium.TARGETLANG.relabel  - pair-specific relabelling, manually add/maint.
 
 Replace TARGETLANG with the language code of the actual target language you
-are building your Livvi apertium analyser for.
+are building your Livvi Karelian apertium analyser for.
 
 
 The file apertium.postproc.relabel is added to all languages and contain some


### PR DESCRIPTION
 instead of Olonets/Olonetsian/Livvi/Livvi-Karelian

I didn't change the authors or citation cause there were mentions of the old repo like gtlangs-olo and idk what to do with that